### PR TITLE
Fix typo in the BROWSERSTACK_USERNAME env var

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -14,7 +14,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: npm install, build, and test
       env:
-        BROWSERSTACK_USER_NAME: ${{ secrets.BROWSERSTACK_USER_NAME }}
+        BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USER_NAME }}
         BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
       run: |
         npm install
@@ -39,7 +39,7 @@ jobs:
         npm run build
     - name: run example with Browserstack local
       env:
-        BROWSERSTACK_USER_NAME: ${{ secrets.BROWSERSTACK_USER_NAME }}
+        BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USER_NAME }}
         BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
       run: |
         cd examples/with-bt-local

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -14,7 +14,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: npm install, build, and test
       env:
-        BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USER_NAME }}
+        BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
         BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
       run: |
         npm install
@@ -39,7 +39,7 @@ jobs:
         npm run build
     - name: run example with Browserstack local
       env:
-        BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USER_NAME }}
+        BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
         BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
       run: |
         cd examples/with-bt-local

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ describe('my visual test', () => {
 
 ### Credentials
 
-If you aren't willing to put your credentials in your `package.json` file, you can export in your environment `BROWSERSTACK_USER_NAME` and `BROWSERSTACK_ACCESS_KEY`. If you do so, `userName` and `accessKey` can be omitted.
+If you aren't willing to put your credentials in your `package.json` file, you can export in your environment `BROWSERSTACK_USERNAME` and `BROWSERSTACK_ACCESS_KEY`. If you do so, `userName` and `accessKey` can be omitted.
 
 ## Examples
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,10 +32,10 @@ export default class BrowserstackEnvironment extends NodeEnvironment {
     const opts = this.btCapabilities['bstack:options'];
 
     if (!opts.accessKey || !opts.userName) {
-      const { BROWSERSTACK_USER_NAME: userName = '', BROWSERSTACK_ACCESS_KEY: accessKey = '' } = process.env;
+      const { BROWSERSTACK_USERNAME: userName = '', BROWSERSTACK_ACCESS_KEY: accessKey = '' } = process.env;
 
       if (!userName || !accessKey) {
-        throw new Error('valid credentials for Browserstack are requierd');
+        throw new Error('valid credentials for Browserstack are required');
       }
 
       this.btCapabilities['bstack:options'].accessKey = accessKey;


### PR DESCRIPTION
From https://www.browserstack.com/automate/cucumber-integration,
The correct syntax is BROWSERSTACK_USERNAME not BROWSERSTACK_USER_NAME

RUN_ON_BSTACK=true BROWSERSTACK_USERNAME=USERNAME BROWSERSTACK_ACCESS_KEY=ACCESS_KEY bundle exec cucumber