### PR TITLE
Allow resize of the window and dynamically set the browserstack session name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,11 +14,11 @@ export default class BrowserstackEnvironment extends NodeEnvironment {
 
   private readonly selHubUrl: string;
 
-  private readonly btCapabilities: BrowserstackCapabilities;
+  private btCapabilities: BrowserstackCapabilities;
 
   private btTunnelOpts: Options;
 
-  private readonly drivers: WebDriver[];
+  private drivers: WebDriver[];
 
   constructor(config: Config.ProjectConfig) {
     super(config);


### PR DESCRIPTION
This will allow the resize of the window with 
await browser.manage().window().setRect({ x: 0, y: 0, width: options.width, height: 1000} )

Also, it allows dynamically set the browserstack session name to include other environment variables instead of just the selenium session id. 